### PR TITLE
removing Drop script checkbox from Configuration modal

### DIFF
--- a/nerdlets/pathpoint-nerdlet/__test__/components/Modal/GeneralConfigurationFormModal.test.js
+++ b/nerdlets/pathpoint-nerdlet/__test__/components/Modal/GeneralConfigurationFormModal.test.js
@@ -253,8 +253,8 @@ describe('<GeneralConfigurationFormModal/>', () => {
     FormControl.simulate('change', e);
     const FormControl2 = component.find('input').at(1);
     FormControl2.simulate('change', e);
-    const FormControl3 = component.find('input').at(2);
-    FormControl3.simulate('change', e);
+    // const FormControl3 = component.find('input').at(2);
+    // FormControl3.simulate('change', e);
     expect(component.exists()).toBe(true);
   });
 });

--- a/nerdlets/pathpoint-nerdlet/__test__/components/Modal/__snapshots__/GeneralConfigurationFormModal.spec.js.snap
+++ b/nerdlets/pathpoint-nerdlet/__test__/components/Modal/__snapshots__/GeneralConfigurationFormModal.spec.js.snap
@@ -210,27 +210,6 @@ exports[`<GeneralConfigurationFormModal/> BodyGeneralConfiguration Component 1`]
       <div
         style={
           Object {
-            "marginTop": "10px",
-          }
-        }
-      >
-        <input
-          defaultChecked={false}
-          disabled={true}
-          id="dropToolsCheck"
-          onChange={[Function]}
-          type="checkbox"
-          value={false}
-        />
-        <label
-          className="label-checkbox"
-        >
-          Enable Drop Filter Background Script
-        </label>
-      </div>
-      <div
-        style={
-          Object {
             "display": "flex",
             "justifyContent": "flex-end",
             "marginTop": "20px",

--- a/nerdlets/pathpoint-nerdlet/components/Modal/GeneralConfigurationFormModal.js
+++ b/nerdlets/pathpoint-nerdlet/components/Modal/GeneralConfigurationFormModal.js
@@ -156,7 +156,7 @@ function BodyGeneralConfigurationFormModal(props) {
               Enable Flame Filter Background Script
             </label>
           </div>
-          <div style={{ marginTop: '10px' }}>
+          {/* <div style={{ marginTop: '10px' }}>
             <input
               type="checkbox"
               id="dropToolsCheck"
@@ -184,7 +184,7 @@ function BodyGeneralConfigurationFormModal(props) {
             <label className="label-checkbox">
               Enable Drop Filter Background Script
             </label>
-          </div>
+          </div> */}
           <div
             style={{
               marginTop: '20px',


### PR DESCRIPTION
This menu item needs to be hidden until the background feature that supports it is complete.<img width="936" alt="enable_drop_filter_must_be_hidden" src="https://user-images.githubusercontent.com/8333200/144495930-e0137e95-2ce3-4f38-9596-8df2f3345ef3.png">
