### PR TITLE
Changing the project version and removing security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
     "name": "PathpointCore",
-    "version": "1.5.6",
+    "version": "1.5.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "PathpointCore",
-            "version": "1.5.6",
+            "version": "1.5.8",
             "dependencies": {
                 "ajv": "^7.0.3",
+                "ansi-regex": ">=5.0.1",
                 "axios": "^0.26.0",
                 "css-what": "^5.1.0",
                 "jest-environment-jsdom": "^27.0.6",
+                "nanoid": ">=3.1.31",
                 "prop-types": "^15.6.2",
                 "react-bootstrap": "^0.33.1",
                 "react-device-detect": "^2.1.2",
@@ -30,6 +32,7 @@
                 "@newrelic/eslint-plugin-newrelic": "^0.3.0",
                 "@semantic-release/changelog": "^5.0.1",
                 "@semantic-release/git": "^9.0.0",
+                "ansi-regex": ">=5.0.1",
                 "babel-eslint": "^10.1.0",
                 "babel-jest": "^27.3.1",
                 "babel-plugin-transform-class-properties": "^6.24.1",
@@ -43,6 +46,7 @@
                 "jest": "^26.6.3",
                 "jsdom": "17.0.0",
                 "jsdom-global": "3.0.2",
+                "nanoid": ">=3.1.31",
                 "prettier": "^1.19.1",
                 "react": "^16.6.3",
                 "react-dom": "^16.6.3",
@@ -12355,9 +12359,16 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "2.1.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-            "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+            "dev": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
         "node_modules/nanomatch": {
             "version": "1.2.13",
@@ -14353,6 +14364,11 @@
             "dependencies": {
                 "nanoid": "^2.1.0"
             }
+        },
+        "node_modules/shortid/node_modules/nanoid": {
+            "version": "2.1.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+            "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
         },
         "node_modules/side-channel": {
             "version": "1.0.4",
@@ -25395,9 +25411,10 @@
             "dev": true
         },
         "nanoid": {
-            "version": "2.1.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-            "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+            "dev": true
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -26971,6 +26988,13 @@
             "integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
             "requires": {
                 "nanoid": "^2.1.0"
+            },
+            "dependencies": {
+                "nanoid": {
+                    "version": "2.1.11",
+                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
+                    "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+                }
             }
         },
         "side-channel": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "name": "PathpointCore",
-    "version": "1.5.6",
+    "version": "1.5.8",
     "scripts": {
         "start": "nr1 nerdpack:serve",
         "samanez": "nr1 nerdpack:serve --profile=samanez",
@@ -25,7 +25,9 @@
         "react-device-detect": "^2.1.2",
         "react-download-link": "^2.3.0",
         "react-html-parser": "^2.0.2",
-        "shortid": "^2.2.16"
+        "shortid": "^2.2.16",
+        "ansi-regex": ">=5.0.1",
+        "nanoid": ">=3.1.31"
     },
     "browserslist": [
         "last 2 versions",
@@ -59,7 +61,9 @@
         "prettier": "^1.19.1",
         "react": "^16.6.3",
         "react-dom": "^16.6.3",
-        "react-test-renderer": "^17.0.1"
+        "react-test-renderer": "^17.0.1",
+        "ansi-regex": ">=5.0.1",
+        "nanoid": ">=3.1.31"
     },
     "jest": {
         "setupFilesAfterEnv": [


### PR DESCRIPTION
- Version Update to 1.5.8
- FIX: Inefficient Regular Expression Complexity in chalk/ansi-regex
- FIX: Exposure of Sensitive Information to an Unauthorized Actor in nanoid