### PR TITLE
URL changed

### DIFF
--- a/catalog/documentation.md
+++ b/catalog/documentation.md
@@ -80,7 +80,7 @@ Visit [https://one.newrelic.com](https://one.newrelic.com), navigate to the Nerd
 
 As noted in our [security policy](https://github.com/newrelic/nr1-pathpoint/security/policy), New Relic is committed to the privacy and security of our customers and their data. We believe that providing coordinated disclosure by security researchers and engaging with the security community are important means to achieve our security goals.
 
-If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [HackerOne](https://hackerone.com/newrelic).
+If you believe you have found a security vulnerability in this project or any of New Relic's products or websites, we welcome and greatly appreciate you reporting it to New Relic through [our bug bounty program](https://docs.newrelic.com/docs/security/security-privacy/information-security/report-security-vulnerabilities/).
 
 ## Issues / enhancement requests
 Issues and enhancement requests can be submitted in the [Issues tab of this repository](https://github.com/newrelic/nr1-pathpoint/issues). Please search for and review the existing open issues before submitting a new issue.


### PR DESCRIPTION
We are changing from HackerOne to BugCrowd for vulnerability reporting hence the doc change