### PR TITLE
fixing updateing configuration

### DIFF
--- a/nerdlets/pathpoint-nerdlet/services/DataManager.js
+++ b/nerdlets/pathpoint-nerdlet/services/DataManager.js
@@ -2503,9 +2503,7 @@ export default class DataManager {
               success_percentage: 0
             };
           }
-          if (query.accountID !== this.accountId) {
-            measure = { accountID: query.accountID, ...measure };
-          }
+          measure = { accountID: query.accountID, ...measure };
           /*
            if (query.measure_time !== TimeRangeTransform(this.timeRange)) {
             measure = { ...measure, measure_time: query.measure_time };


### PR DESCRIPTION
After updating the pathpoint configuration using the GUI editor, the reference to the accountID in the touchPoints object is lost.
This change solve this issue.